### PR TITLE
Feat/stream creator cancel

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -280,6 +280,7 @@ pub fn execute_create_stream(
         config.stream_creation_denom,
         config.stream_creation_fee,
         config.exit_fee_percent,
+        info.sender,
     );
     let id = next_stream_id(deps.storage)?;
     STREAMS.save(deps.storage, id, &stream)?;
@@ -1143,6 +1144,7 @@ pub fn query_stream(deps: Deps, _env: Env, stream_id: u64) -> StdResult<StreamRe
         current_streamed_price: stream.current_streamed_price,
         exit_fee_percent: stream.stream_exit_fee_percent,
         stream_creation_fee: stream.stream_creation_fee,
+        stream_creator_address: stream.stream_creator_addr.to_string(),
     };
     Ok(stream)
 }
@@ -1183,6 +1185,7 @@ pub fn list_streams(
                 current_streamed_price: stream.current_streamed_price,
                 exit_fee_percent: stream.stream_exit_fee_percent,
                 stream_creation_fee: stream.stream_creation_fee,
+                stream_creator_address: stream.stream_creator_addr.to_string(),
             };
             Ok(stream)
         })

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -229,6 +229,8 @@ pub struct StreamResponse {
     pub exit_fee_percent: Decimal,
     /// Creation fee amount.
     pub stream_creation_fee: Uint128,
+    /// Address of the stream creator.
+    pub stream_creator_address: String,
 }
 
 #[cw_serde]

--- a/src/state.rs
+++ b/src/state.rs
@@ -68,6 +68,8 @@ pub struct Stream {
     pub stream_creation_fee: Uint128,
     /// Stream swap fee in percent. Saved under here to avoid any changes in config to efect existing streams.
     pub stream_exit_fee_percent: Decimal,
+    /// Address of the stream creator.
+    pub stream_creator_addr: Addr,
 }
 
 #[cw_serde]
@@ -94,6 +96,7 @@ impl Stream {
         stream_creation_denom: String,
         stream_creation_fee: Uint128,
         stream_exit_fee_percent: Decimal,
+        stream_creator_addr: Addr,
     ) -> Self {
         Stream {
             name,
@@ -116,6 +119,7 @@ impl Stream {
             stream_creation_denom,
             stream_creation_fee,
             stream_exit_fee_percent,
+            stream_creator_addr,
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3875,5 +3875,118 @@ mod test_module {
             assert_eq!(stream.dist_index, Decimal256::zero());
             assert_eq!(stream.shares, Uint128::new(0));
         }
+        #[test]
+        pub fn test_creator_cancel() {
+            let treasury = Addr::unchecked("treasury");
+            let start = 1_000_000;
+            let end = 5_000_000;
+            let out_supply = Uint128::new(1_000_000_000_000);
+            let out_denom = "out_denom";
+
+            // instantiate
+            let mut deps = mock_dependencies();
+            let mut env = mock_env();
+            env.block.height = 0;
+            let msg = crate::msg::InstantiateMsg {
+                min_stream_blocks: 1_000,
+                min_blocks_until_start_block: 1_000,
+                stream_creation_denom: "fee".to_string(),
+                stream_creation_fee: Uint128::new(100),
+                exit_fee_percent: Decimal::percent(1),
+                fee_collector: "collector".to_string(),
+                protocol_admin: "protocol_admin".to_string(),
+                accepted_in_denom: "in".to_string(),
+            };
+            instantiate(deps.as_mut(), mock_env(), mock_info("creator", &[]), msg).unwrap();
+
+            // create stream
+            let mut env = mock_env();
+            env.block.height = 0;
+            let info = mock_info(
+                "creator",
+                &[
+                    Coin::new(out_supply.u128(), out_denom),
+                    Coin::new(100, "fee"),
+                ],
+            );
+            execute_create_stream(
+                deps.as_mut(),
+                env,
+                info,
+                treasury.to_string(),
+                "test".to_string(),
+                Some("https://sample.url".to_string()),
+                "in".to_string(),
+                out_denom.to_string(),
+                out_supply,
+                start,
+                end,
+            )
+            .unwrap();
+
+            // subscription
+            let mut env = mock_env();
+            env.block.height = start;
+            let funds = Coin::new(2_000_000_000_000, "in");
+            let info = mock_info("subscriber", &[funds.clone()]);
+            let msg = crate::msg::ExecuteMsg::Subscribe {
+                stream_id: 1,
+                operator_target: None,
+                operator: Some("operator".to_string()),
+            };
+            let _res = execute(deps.as_mut(), env, info, msg).unwrap();
+
+            // Random creator can't cancel
+            let mut env = mock_env();
+            env.block.height = 100;
+            let info = mock_info("random", &[]);
+            let res = execute_cancel_stream(deps.as_mut(), env, info, 1).unwrap_err();
+            assert_eq!(res, ContractError::Unauthorized {});
+
+            // creator can not cancel too near to start block
+            let mut env = mock_env();
+            env.block.height = start - 499;
+            let info = mock_info("creator", &[]);
+            let res = execute_cancel_stream(deps.as_mut(), env, info, 1).unwrap_err();
+            assert_eq!(res, ContractError::Unauthorized {});
+
+            // creator can cancel
+            let mut env = mock_env();
+            env.block.height = start - 500;
+            let info = mock_info("creator", &[]);
+            let res = execute_cancel_stream(deps.as_mut(), env, info, 1).unwrap();
+            assert_eq!(res.attributes[0].value, "cancel_stream");
+
+            // check stream
+            let stream = query_stream(deps.as_ref(), mock_env(), 1).unwrap();
+            assert_eq!(stream.status, Status::Cancelled);
+            assert_eq!(stream.in_supply, Uint128::new(2_000_000_000_000));
+            assert_eq!(stream.dist_index, Decimal256::zero());
+            assert_eq!(stream.shares, Uint128::new(2_000_000_000_000));
+            assert_eq!(stream.spent_in, Uint128::zero());
+
+            // creator can't cancel again
+            let mut env = mock_env();
+            env.block.height = start - 500;
+            let info = mock_info("creator", &[]);
+            let res = execute_cancel_stream(deps.as_mut(), env, info, 1).unwrap_err();
+            assert_eq!(res, ContractError::StreamIsCancelled {});
+
+            // subcriber can exit
+            let mut env = mock_env();
+            env.block.height = start + 1_000_000;
+            let info = mock_info("subscriber", &[]);
+            let res = execute_exit_cancelled(deps.as_mut(), env, info, 1, None).unwrap();
+            assert_eq!(
+                res.messages[0].msg,
+                CosmosMsg::Bank(BankMsg::Send {
+                    to_address: "subscriber".to_string(),
+                    amount: vec![funds]
+                })
+            );
+            // check stream
+            let stream = query_stream(deps.as_ref(), mock_env(), 1).unwrap();
+            assert_eq!(stream.in_supply, Uint128::new(0));
+        }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,6 +35,7 @@ mod test_module {
             "fee".to_string(),
             Uint128::from(100u128),
             Decimal::percent(10),
+            Addr::unchecked("creator"),
         );
 
         // add new shares


### PR DESCRIPTION
Changes 
- Now stream creator can cancel stream without pausing 
- This can be done within half of the amount of min_blocks_until_start_block