### PR TITLE
Seperate sudo functions in killswich is removed

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -138,13 +138,13 @@ pub fn execute(
         } => execute_exit_stream(deps, env, info, stream_id, operator_target),
 
         ExecuteMsg::PauseStream { stream_id } => {
-            killswitch::execute_pause_stream(deps, env, info, stream_id)
+            killswitch::execute_pause_stream(deps, env, info, stream_id, false)
         }
         ExecuteMsg::ResumeStream { stream_id } => {
-            killswitch::execute_resume_stream(deps, env, info, stream_id)
+            killswitch::execute_resume_stream(deps, env, info, stream_id, false)
         }
         ExecuteMsg::CancelStream { stream_id } => {
-            killswitch::execute_cancel_stream(deps, env, info, stream_id)
+            killswitch::execute_cancel_stream(deps, env, info, stream_id, false)
         }
         ExecuteMsg::WithdrawPaused {
             stream_id,
@@ -1057,11 +1057,22 @@ fn check_access(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> Result<Response, ContractError> {
+pub fn sudo(
+    deps: DepsMut,
+    env: Env,
+    msg: SudoMsg,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
     match msg {
-        SudoMsg::PauseStream { stream_id } => killswitch::sudo_pause_stream(deps, env, stream_id),
-        SudoMsg::CancelStream { stream_id } => killswitch::sudo_cancel_stream(deps, env, stream_id),
-        SudoMsg::ResumeStream { stream_id } => killswitch::sudo_resume_stream(deps, env, stream_id),
+        SudoMsg::PauseStream { stream_id } => {
+            killswitch::execute_pause_stream(deps, env, info, stream_id, true)
+        }
+        SudoMsg::CancelStream { stream_id } => {
+            killswitch::execute_cancel_stream(deps, env, info, stream_id, true)
+        }
+        SudoMsg::ResumeStream { stream_id } => {
+            killswitch::execute_resume_stream(deps, env, info, stream_id, true)
+        }
     }
 }
 

--- a/src/killswitch.rs
+++ b/src/killswitch.rs
@@ -146,9 +146,10 @@ pub fn execute_pause_stream(
     env: Env,
     info: MessageInfo,
     stream_id: u64,
+    is_sudo: bool,
 ) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
-    if info.sender != config.protocol_admin {
+    if info.sender != config.protocol_admin && !is_sudo {
         return Err(ContractError::Unauthorized {});
     }
     //check if stream is ended
@@ -184,6 +185,7 @@ pub fn execute_resume_stream(
     env: Env,
     info: MessageInfo,
     stream_id: u64,
+    is_sudo: bool,
 ) -> Result<Response, ContractError> {
     let mut stream = STREAMS.load(deps.storage, stream_id)?;
     let cfg = CONFIG.load(deps.storage)?;
@@ -194,7 +196,7 @@ pub fn execute_resume_stream(
     if stream.status != Status::Paused {
         return Err(ContractError::StreamNotPaused {});
     }
-    if cfg.protocol_admin != info.sender {
+    if cfg.protocol_admin != info.sender && !is_sudo {
         return Err(ContractError::Unauthorized {});
     }
 
@@ -225,10 +227,11 @@ pub fn execute_cancel_stream(
     env: Env,
     info: MessageInfo,
     stream_id: u64,
+    is_sudo: bool,
 ) -> Result<Response, ContractError> {
     let cfg = CONFIG.load(deps.storage)?;
     let mut stream = STREAMS.load(deps.storage, stream_id)?;
-    if cfg.protocol_admin != info.sender && stream.stream_creator_addr != info.sender {
+    if cfg.protocol_admin != info.sender && stream.stream_creator_addr != info.sender && !is_sudo {
         return Err(ContractError::Unauthorized {});
     }
     if stream.is_cancelled() {
@@ -281,109 +284,109 @@ pub fn execute_cancel_stream(
         .add_attribute("status", "cancelled"))
 }
 
-pub fn sudo_pause_stream(
-    deps: DepsMut,
-    env: Env,
-    stream_id: u64,
-) -> Result<Response, ContractError> {
-    let mut stream = STREAMS.load(deps.storage, stream_id)?;
+// pub fn sudo_pause_stream(
+//     deps: DepsMut,
+//     env: Env,
+//     stream_id: u64,
+// ) -> Result<Response, ContractError> {
+//     let mut stream = STREAMS.load(deps.storage, stream_id)?;
 
-    if env.block.height >= stream.end_block {
-        return Err(ContractError::StreamEnded {});
-    }
-    // Paused or cancelled can not be paused
-    if stream.is_killswitch_active() {
-        return Err(ContractError::StreamKillswitchActive {});
-    }
-    update_stream(env.block.height, &mut stream)?;
-    pause_stream(env.block.height, &mut stream)?;
-    STREAMS.save(deps.storage, stream_id, &stream)?;
+//     if env.block.height >= stream.end_block {
+//         return Err(ContractError::StreamEnded {});
+//     }
+//     // Paused or cancelled can not be paused
+//     if stream.is_killswitch_active() {
+//         return Err(ContractError::StreamKillswitchActive {});
+//     }
+//     update_stream(env.block.height, &mut stream)?;
+//     pause_stream(env.block.height, &mut stream)?;
+//     STREAMS.save(deps.storage, stream_id, &stream)?;
 
-    Ok(Response::default()
-        .add_attribute("action", "sudo_pause_stream")
-        .add_attribute("stream_id", stream_id.to_string())
-        .add_attribute("is_paused", "true")
-        .add_attribute("pause_block", env.block.height.to_string()))
-}
+//     Ok(Response::default()
+//         .add_attribute("action", "sudo_pause_stream")
+//         .add_attribute("stream_id", stream_id.to_string())
+//         .add_attribute("is_paused", "true")
+//         .add_attribute("pause_block", env.block.height.to_string()))
+// }
 
-pub fn sudo_resume_stream(
-    deps: DepsMut,
-    env: Env,
-    stream_id: u64,
-) -> Result<Response, ContractError> {
-    let mut stream = STREAMS.load(deps.storage, stream_id)?;
-    //Cancelled can't be resumed
-    if stream.is_cancelled() {
-        return Err(ContractError::StreamIsCancelled {});
-    }
-    //Only paused can be resumed
-    if !stream.is_paused() {
-        return Err(ContractError::StreamNotPaused {});
-    }
-    // ok to use unwrap here
-    let pause_block = stream.pause_block.unwrap();
-    if env.block.height < stream.start_block {
-        // If stream is paused before start block, then we need we dont need to update
-        // stream start block and last updated block
-        stream.status = Status::Waiting;
-        stream.pause_block = None;
-    } else {
-        //postpone stream times with respect to pause duration
-        stream.end_block = stream.end_block + (env.block.height - pause_block);
-        stream.last_updated_block = stream.last_updated_block + (env.block.height - pause_block);
-        stream.status = Status::Active;
-        stream.pause_block = None;
-    }
-    STREAMS.save(deps.storage, stream_id, &stream)?;
+// pub fn sudo_resume_stream(
+//     deps: DepsMut,
+//     env: Env,
+//     stream_id: u64,
+// ) -> Result<Response, ContractError> {
+//     let mut stream = STREAMS.load(deps.storage, stream_id)?;
+//     //Cancelled can't be resumed
+//     if stream.is_cancelled() {
+//         return Err(ContractError::StreamIsCancelled {});
+//     }
+//     //Only paused can be resumed
+//     if !stream.is_paused() {
+//         return Err(ContractError::StreamNotPaused {});
+//     }
+//     // ok to use unwrap here
+//     let pause_block = stream.pause_block.unwrap();
+//     if env.block.height < stream.start_block {
+//         // If stream is paused before start block, then we need we dont need to update
+//         // stream start block and last updated block
+//         stream.status = Status::Waiting;
+//         stream.pause_block = None;
+//     } else {
+//         //postpone stream times with respect to pause duration
+//         stream.end_block = stream.end_block + (env.block.height - pause_block);
+//         stream.last_updated_block = stream.last_updated_block + (env.block.height - pause_block);
+//         stream.status = Status::Active;
+//         stream.pause_block = None;
+//     }
+//     STREAMS.save(deps.storage, stream_id, &stream)?;
 
-    Ok(Response::default()
-        .add_attribute("action", "resume_stream")
-        .add_attribute("stream_id", stream_id.to_string())
-        .add_attribute("new_end_date", stream.end_block.to_string())
-        .add_attribute("status", "active"))
-}
+//     Ok(Response::default()
+//         .add_attribute("action", "resume_stream")
+//         .add_attribute("stream_id", stream_id.to_string())
+//         .add_attribute("new_end_date", stream.end_block.to_string())
+//         .add_attribute("status", "active"))
+// }
 
-pub fn sudo_cancel_stream(
-    deps: DepsMut,
-    _env: Env,
-    stream_id: u64,
-) -> Result<Response, ContractError> {
-    let mut stream = STREAMS.load(deps.storage, stream_id)?;
-    if stream.is_cancelled() {
-        return Err(ContractError::StreamIsCancelled {});
-    }
-    if !stream.is_paused() {
-        return Err(ContractError::StreamNotPaused {});
-    }
-    stream.status = Status::Cancelled;
-    // If stream is cancelled We can reset in supply and spent in
-    stream.in_supply = stream.in_supply.checked_add(stream.spent_in)?;
-    stream.spent_in = Uint128::zero();
-    STREAMS.save(deps.storage, stream_id, &stream)?;
-    STREAMS.save(deps.storage, stream_id, &stream)?;
+// pub fn sudo_cancel_stream(
+//     deps: DepsMut,
+//     _env: Env,
+//     stream_id: u64,
+// ) -> Result<Response, ContractError> {
+//     let mut stream = STREAMS.load(deps.storage, stream_id)?;
+//     if stream.is_cancelled() {
+//         return Err(ContractError::StreamIsCancelled {});
+//     }
+//     if !stream.is_paused() {
+//         return Err(ContractError::StreamNotPaused {});
+//     }
+//     stream.status = Status::Cancelled;
+//     // If stream is cancelled We can reset in supply and spent in
+//     stream.in_supply = stream.in_supply.checked_add(stream.spent_in)?;
+//     stream.spent_in = Uint128::zero();
+//     STREAMS.save(deps.storage, stream_id, &stream)?;
+//     STREAMS.save(deps.storage, stream_id, &stream)?;
 
-    //Refund all out tokens to stream creator(treasury)
-    let messages: Vec<CosmosMsg> = vec![
-        CosmosMsg::Bank(BankMsg::Send {
-            to_address: stream.treasury.to_string(),
-            amount: vec![Coin {
-                denom: stream.out_denom,
-                amount: stream.out_supply,
-            }],
-        }),
-        //Refund stream creation fee to stream creator
-        CosmosMsg::Bank(BankMsg::Send {
-            to_address: stream.treasury.to_string(),
-            amount: vec![Coin {
-                denom: stream.stream_creation_denom,
-                amount: stream.stream_creation_fee,
-            }],
-        }),
-    ];
+//     //Refund all out tokens to stream creator(treasury)
+//     let messages: Vec<CosmosMsg> = vec![
+//         CosmosMsg::Bank(BankMsg::Send {
+//             to_address: stream.treasury.to_string(),
+//             amount: vec![Coin {
+//                 denom: stream.out_denom,
+//                 amount: stream.out_supply,
+//             }],
+//         }),
+//         //Refund stream creation fee to stream creator
+//         CosmosMsg::Bank(BankMsg::Send {
+//             to_address: stream.treasury.to_string(),
+//             amount: vec![Coin {
+//                 denom: stream.stream_creation_denom,
+//                 amount: stream.stream_creation_fee,
+//             }],
+//         }),
+//     ];
 
-    Ok(Response::new()
-        .add_attribute("action", "cancel_stream")
-        .add_messages(messages)
-        .add_attribute("stream_id", stream_id.to_string())
-        .add_attribute("status", "cancelled"))
-}
+//     Ok(Response::new()
+//         .add_attribute("action", "cancel_stream")
+//         .add_messages(messages)
+//         .add_attribute("stream_id", stream_id.to_string())
+//         .add_attribute("status", "cancelled"))
+// }


### PR DESCRIPTION
Changes
- sudo_cancel_stream,sudo_pause_stream,sudo_resume_stream functions removed
- Sudo messages now executes same functions as protocol admin